### PR TITLE
Fixes VAULT_TOKEN usage and multiple paths per mount

### DIFF
--- a/lib/puppet/functions/hiera_vault.rb
+++ b/lib/puppet/functions/hiera_vault.rb
@@ -88,10 +88,12 @@ Puppet::Functions.create_function(:hiera_vault) do
     begin
       $vault.configure do |config|
         config.address = options['address'] unless options['address'].nil?
-        if options['token'].start_with?('/') and File.exist?(options['token'])
-          config.token = File.read(options['token']).strip.chomp
-        else
-          config.token = options['token']
+        unless options['token'].nil?
+          if options['token'].start_with?('/') and File.exist?(options['token'])
+            config.token = File.read(options['token']).strip.chomp
+          else
+            config.token = options['token']
+          end
         end
         config.ssl_pem_file = options['ssl_pem_file'] unless options['ssl_pem_file'].nil?
         config.ssl_verify = options['ssl_verify'] unless options['ssl_verify'].nil?


### PR DESCRIPTION
I've noticed 2 issues:
- Using the VAULT_TOKEN variable (without specifying `token:`) doesn't work.
- Multiple paths per mount (as shown in the example) are mashed together and not queried in sequence.

This PR fixes both.