### PR TITLE
WIP: Fetch Vault token from file

### DIFF
--- a/lib/puppet/functions/hiera_vault.rb
+++ b/lib/puppet/functions/hiera_vault.rb
@@ -76,7 +76,13 @@ Puppet::Functions.create_function(:hiera_vault) do
 
       vault.configure do |config|
         config.address = options['address'] unless options['address'].nil?
-        config.token = options['token'] unless options['token'].nil?
+        if options['token'].nil?
+          unless options['envvar'].nil?
+            config.token = ENV[options['envvar']]
+          end
+        else
+          config.token = options['token']
+        end
         config.ssl_pem_file = options['ssl_pem_file'] unless options['ssl_pem_file'].nil?
         config.ssl_verify = options['ssl_verify'] unless options['ssl_verify'].nil?
         config.ssl_ca_cert = options['ssl_ca_cert'] if config.respond_to? :ssl_ca_cert

--- a/lib/puppet/functions/hiera_vault.rb
+++ b/lib/puppet/functions/hiera_vault.rb
@@ -25,7 +25,6 @@ Puppet::Functions.create_function(:hiera_vault) do
   end
 
   def lookup_key(key, options, context)
-
     if confine_keys = options['confine_to_keys']
       raise ArgumentError, '[hiera-vault] confine_to_keys must be an array' unless confine_keys.is_a?(Array)
 
@@ -62,7 +61,6 @@ Puppet::Functions.create_function(:hiera_vault) do
 
 
   def vault_get(key, options, context)
-
     if ! ['string','json',nil].include?(options['default_field_parse'])
       raise ArgumentError, "[hiera-vault] invalid value for default_field_parse: '#{options['default_field_behavior']}', should be one of 'string','json'"
     end
@@ -76,9 +74,9 @@ Puppet::Functions.create_function(:hiera_vault) do
 
       vault.configure do |config|
         config.address = options['address'] unless options['address'].nil?
-        if options['token'].nil?
-          if options['envvar'] != nil && options['envvar'] != '' && ENV.has_key?(options['envvar'])
-            config.token = ENV[options['envvar']]
+        if options['token'].nil? || options['token'] == ''
+          if options['tokenfile'] != nil && options['tokenfile'] != ''
+            config.token = File.read(options['tokenfile']).strip
           end
         else
           config.token = options['token']

--- a/lib/puppet/functions/hiera_vault.rb
+++ b/lib/puppet/functions/hiera_vault.rb
@@ -77,7 +77,7 @@ Puppet::Functions.create_function(:hiera_vault) do
       vault.configure do |config|
         config.address = options['address'] unless options['address'].nil?
         if options['token'].nil?
-          unless options['envvar'].nil?
+          if options['envvar'] != nil && options['envvar'] != '' && ENV.has_key?(options['envvar'])
             config.token = ENV[options['envvar']]
           end
         else

--- a/lib/puppet/functions/hiera_vault.rb
+++ b/lib/puppet/functions/hiera_vault.rb
@@ -50,10 +50,6 @@ Puppet::Functions.create_function(:hiera_vault) do
       end
     end
 
-    if ENV['VAULT_TOKEN'] == 'IGNORE-VAULT'
-      return context.not_found
-    end
-
     result = vault_get(key, options, context)
 
     return result
@@ -71,6 +67,7 @@ Puppet::Functions.create_function(:hiera_vault) do
 
     begin
       vault = Vault::Client.new
+      return context.not_found if vault.token == 'IGNORE-VAULT'
 
       vault.configure do |config|
         config.address = options['address'] unless options['address'].nil?

--- a/lib/puppet/functions/hiera_vault.rb
+++ b/lib/puppet/functions/hiera_vault.rb
@@ -75,7 +75,7 @@ Puppet::Functions.create_function(:hiera_vault) do
       vault.configure do |config|
         config.address = options['address'] unless options['address'].nil?
         if options['token'].nil? || options['token'] == ''
-          if options['tokenfile'] != nil && options['tokenfile'] != ''
+          if options['tokenfile'] != nil && options['tokenfile'] != '' && File.exist?(options['tokenfile'])
             config.token = File.read(options['tokenfile']).strip
           end
         else


### PR DESCRIPTION
In our setup, we have multiple Vault locations to read from. Some are even on different Vault clusters (QA Vault for QA servers). They all go through the same Puppet master. For this reason, we added a `tokenfile` option, which contains the Vault token for that particular hiera scope. Eg, inside module "Mymodule":

```yaml
hierarchy:
  - name: "Hiera-vault lookup Mymodule P"
    lookup_key: hiera_vault
    options:
      confine_to_keys:
        - "^mymodule::vaultp::.*"
      strip_from_keys:
        - "^mymodule::vaultp::"
      ssl_verify: true
      address: https://vault-p.example.org
      default_field: value
      default_field_parse: json
      mounts:
        generic:
          - secret/projects/icts-p-mymodule
  - name: "Hiera-vault lookup Mymodule Q"
    lookup_key: hiera_vault
    options:
      confine_to_keys:
        - "^mymodule::vaultq::.*"
      strip_from_keys:
        - "^mymodule::vaultq::"
      ssl_verify: true
      address: https://vault-q.example.org
      tokenfile: /opt/puppetlabs/server/data/puppetserver/.vault-token-q
      default_field: value
      default_field_parse: json
      mounts:
        generic:
          - secret/projects/icts-q-mymodule
```

The configuration for P used the default token in the environment, while the configuration for Q uses the token found in `/opt/puppetlabs/server/data/puppetserver/.vault-token-q`.