### PR TITLE
Add comma based multi-pathing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: Test
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_WITHOUT: development
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          # Can't use jruby-9.1.17.0 due to issues with bundler 2.X: https://github.com/ruby/setup-ruby/issues/108
+          ruby-version: jruby-9.2.9.0
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - run: bundle exec rspec

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,11 @@ jobs:
     env:
       BUNDLE_WITHOUT: development
     steps:
+      - name: Install vault
+        run: |
+          curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+          sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+          sudo apt-get update && sudo apt-get install vault
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
         with:

--- a/.jrubyrc
+++ b/.jrubyrc
@@ -1,0 +1,1 @@
+debug.fullTrace=true

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
 --color
 --format documentation
 --backtrace
+--pattern 'spec/functions/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :test do
 
   gem 'rake'
   gem 'puppet-lint'
+  gem 'rspec'
   gem 'rspec-puppet'
   gem 'puppet-syntax'
   gem 'puppetlabs_spec_helper'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,7 @@ GEM
       faraday (~> 0.8)
     fast_gettext (1.1.2)
     ffi (1.9.25)
+    ffi (1.9.25-java)
     gettext (3.2.9)
       locale (>= 2.0.5)
       text (>= 1.3.0)
@@ -49,6 +50,7 @@ GEM
       retriable (~> 3.0)
     hiera (3.7.0)
     hitimes (1.3.0)
+    hitimes (1.3.0-java)
     hocon (1.3.1)
     http-accept (1.7.0)
     http-cookie (1.0.3)
@@ -57,7 +59,9 @@ GEM
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
+    jaro_winkler (1.5.4-java)
     json (2.3.0)
+    json (2.3.0-java)
     json-schema (2.8.0)
       addressable (>= 2.4)
     json_pure (2.1.0)
@@ -107,6 +111,10 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry (0.12.2-java)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+      spoon (~> 0.0)
     public_suffix (4.0.1)
     puppet (6.21.1)
       concurrent-ruby (~> 1.0)
@@ -181,10 +189,13 @@ GEM
       terminal-table
     simplecov-html (0.10.2)
     spdx-licenses (1.2.0)
+    spoon (0.0.6)
+      ffi
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     text (1.3.1)
     thread_safe (0.3.6)
+    thread_safe (0.3.6-java)
     tty-color (0.5.0)
     tty-cursor (0.7.0)
     tty-prompt (0.20.0)
@@ -203,7 +214,8 @@ GEM
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.6)
+    unf (0.1.4-java)
+    unf_ext (0.0.7.7)
     unicode-display_width (1.6.0)
     vault (0.13.0)
       aws-sigv4
@@ -211,6 +223,7 @@ GEM
 
 PLATFORMS
   ruby
+  universal-java-16
 
 DEPENDENCIES
   activesupport (< 5)
@@ -227,6 +240,7 @@ DEPENDENCIES
   puppetlabs_spec_helper
   rake
   rb-readline
+  rspec
   rspec-puppet
   rubocop
   rubocop-rspec
@@ -236,4 +250,4 @@ DEPENDENCIES
   vault (>= 0.13.0)
 
 BUNDLED WITH
-   2.0.1
+   2.2.24

--- a/lib/puppet/functions/hiera_vault.rb
+++ b/lib/puppet/functions/hiera_vault.rb
@@ -137,11 +137,15 @@ Puppet::Functions.create_function(:hiera_vault) do
 
         secret = nil
 
-        [
+        paths = [
           [:v1, File.join(mount, path, key)],
           [:v2, File.join(mount, path, 'data', key).chomp('/')],
           [:v2, File.join(mount, 'data', path, key).chomp('/')],
-        ].each do |version_path|
+        ]
+
+        paths << [:v2, File.join(mount, 'data', key).chomp('/')] if key.start_with?(path)
+
+        paths.each do |version_path|
           begin
             version, path = version_path[0], version_path[1]
             context.explain { "[hiera-vault] Checking path: #{path}" }

--- a/lib/puppet/functions/hiera_vault.rb
+++ b/lib/puppet/functions/hiera_vault.rb
@@ -137,13 +137,17 @@ Puppet::Functions.create_function(:hiera_vault) do
 
         secret = nil
 
-        paths = [
-          [:v1, File.join(mount, path, key)],
-          [:v2, File.join(mount, path, 'data', key).chomp('/')],
-          [:v2, File.join(mount, 'data', path, key).chomp('/')],
-        ]
+        paths = []
 
-        paths << [:v2, File.join(mount, 'data', key).chomp('/')] if key.start_with?(path)
+        if options.fetch("v2_guess_mount", true)
+          paths << [:v2, File.join(mount, path, 'data', key).chomp('/')]
+          paths << [:v2, File.join(mount, 'data', path, key).chomp('/')]
+        else
+          paths << [:v2, File.join(mount, path, key).chomp('/')]
+          paths << [:v2, File.join(mount, key).chomp('/')] if key.start_with?(path)
+        end
+
+        paths << [:v1, File.join(mount, path, key)] if options.fetch("v1_lookup", true)
 
         paths.each do |version_path|
           begin

--- a/spec/functions/hiera_vault_happy_path_v2_spec.rb
+++ b/spec/functions/hiera_vault_happy_path_v2_spec.rb
@@ -58,6 +58,7 @@ describe FakeFunction do
           vault_test_client.logical.write('puppetv2/data/common/broken_json_key', { "data" => { value: '[,'} } )
           vault_test_client.logical.write('puppetv2/data/common/confined_vault_key', { "data" => { value: 'find_me'} } )
           vault_test_client.logical.write('puppetv2/data/common/stripped_key', { "data" => { value: 'regexed_key'} } )
+          vault_test_client.logical.write('puppetv2/data/common/complex_structure_key', { "data" => { hash: {a: 1}, array: [1, 2], hash_with_array: {a: [1, 2]}, array_with_hash: [{a: 1}, {b: 2}]} } )
         end
 
         context 'configuring vault' do
@@ -128,6 +129,11 @@ describe FakeFunction do
           it 'should return a hash lacking a default field' do
             expect(function.lookup_key('multiple_values_key', vault_options, context))
               .to include('a' => 1, 'b' => 2, 'c' => 3)
+          end
+
+          it 'should return a complex object' do
+            expect(function.lookup_key('complex_structure_key', vault_options, context))
+              .to include("hash" => {"a" => 1}, "array" => [1, 2], "hash_with_array" => {"a" => [1, 2]}, "array_with_hash" => [{"a" => 1}, {"b" => 2}])
           end
 
           it 'should return an array parsed from json' do

--- a/spec/functions/hiera_vault_path_interpolation_spec.rb
+++ b/spec/functions/hiera_vault_path_interpolation_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+require 'support/vault_server'
+require 'puppet/functions/hiera_vault'
+
+VAULT_PATH ='puppetv2_interpolation'
+
+describe FakeFunction do
+  let :function do
+    described_class.new
+  end
+
+  let :context do
+    ctx = instance_double('Puppet::LookupContext')
+    allow(ctx).to receive(:cache_has_key).and_return(false)
+    if ENV['DEBUG']
+      allow(ctx).to receive(:explain) { |&block| puts(block.call) }
+    else
+      allow(ctx).to receive(:explain).and_return(:nil)
+    end
+    allow(ctx).to receive(:not_found)
+    allow(ctx).to receive(:cache).with(String, anything) do |_, val|
+      val
+    end
+    allow(ctx).to receive(:interpolate).with(anything) do |val|
+      val
+    end
+    ctx
+  end
+
+
+  let :vault_options do
+    {
+      'address' => RSpec::VaultServer.address,
+      'token' => RSpec::VaultServer.token,
+      'mounts' => {
+        VAULT_PATH => [
+          'common',
+          'roles/rproxy,api'
+        ]
+      }
+    }
+  end
+
+  def vault_test_client
+    Vault::Client.new(
+      address: RSpec::VaultServer.address,
+      token: RSpec::VaultServer.token
+    )
+  end
+
+  describe '#lookup_key' do
+    context 'when paths contain options' do
+      context 'when vault is unsealed' do
+        before(:context) do
+          vault_test_client.sys.mount(VAULT_PATH, 'kv', 'puppet secrets v2', { "options" => {"version": "2" }})
+          vault_test_client.logical.write("#{VAULT_PATH}/data/common/test_key", { "data" => { value: 'default'} } )
+          vault_test_client.logical.write("#{VAULT_PATH}/data/roles/rproxy/ssl", { "data" => { value: 'ssl'} } )
+          vault_test_client.logical.write("#{VAULT_PATH}/data/roles/api/oauth", { "data" => { value: 'oauth'} } )
+        end
+
+        context 'reading secrets' do
+          it 'returns key from first option' do
+            expect(function.lookup_key('ssl', vault_options, context))
+              .to include('value' => 'ssl')
+          end
+
+          it 'returns key from second option' do
+            expect(function.lookup_key('oauth', vault_options, context))
+              .to include('value' => 'oauth')
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/functions/hiera_vault_path_interpolation_spec.rb
+++ b/spec/functions/hiera_vault_path_interpolation_spec.rb
@@ -35,7 +35,7 @@ describe FakeFunction do
       'mounts' => {
         VAULT_PATH => [
           'common',
-          'roles/rproxy,api'
+          'rproxy,api'
         ]
       }
     }
@@ -54,8 +54,9 @@ describe FakeFunction do
         before(:context) do
           vault_test_client.sys.mount(VAULT_PATH, 'kv', 'puppet secrets v2', { "options" => {"version": "2" }})
           vault_test_client.logical.write("#{VAULT_PATH}/data/common/test_key", { "data" => { value: 'default'} } )
-          vault_test_client.logical.write("#{VAULT_PATH}/data/roles/rproxy/ssl", { "data" => { value: 'ssl'} } )
-          vault_test_client.logical.write("#{VAULT_PATH}/data/roles/api/oauth", { "data" => { value: 'oauth'} } )
+          vault_test_client.logical.write("#{VAULT_PATH}/data/rproxy/ssl", { "data" => { value: 'ssl'} } )
+          vault_test_client.logical.write("#{VAULT_PATH}/data/api/oauth", { "data" => { value: 'oauth'} } )
+          vault_test_client.logical.write("#{VAULT_PATH}/data/api", { "data" => { value: 'api_specific'} } )
         end
 
         context 'reading secrets' do
@@ -66,6 +67,16 @@ describe FakeFunction do
 
           it 'returns key from second option' do
             expect(function.lookup_key('oauth', vault_options, context))
+              .to include('value' => 'oauth')
+          end
+
+          it 'returns key from second option without leaf node' do
+            expect(function.lookup_key('api', vault_options, context))
+              .to include('value' => 'api_specific')
+          end
+
+          it 'returns key from second option with full path to node' do
+            expect(function.lookup_key('api/oauth', vault_options, context))
               .to include('value' => 'oauth')
           end
         end

--- a/spec/functions/hiera_vault_path_interpolation_spec.rb
+++ b/spec/functions/hiera_vault_path_interpolation_spec.rb
@@ -32,8 +32,10 @@ describe FakeFunction do
     {
       'address' => RSpec::VaultServer.address,
       'token' => RSpec::VaultServer.token,
+      'v2_guess_mount' => false,
+      'v1_lookup' => false,
       'mounts' => {
-        VAULT_PATH => [
+        VAULT_PATH + "/data" => [
           'common',
           'rproxy,api'
         ]
@@ -53,10 +55,10 @@ describe FakeFunction do
       context 'when vault is unsealed' do
         before(:context) do
           vault_test_client.sys.mount(VAULT_PATH, 'kv', 'puppet secrets v2', { "options" => {"version": "2" }})
-          vault_test_client.logical.write("#{VAULT_PATH}/data/common/test_key", { "data" => { value: 'default'} } )
-          vault_test_client.logical.write("#{VAULT_PATH}/data/rproxy/ssl", { "data" => { value: 'ssl'} } )
-          vault_test_client.logical.write("#{VAULT_PATH}/data/api/oauth", { "data" => { value: 'oauth'} } )
-          vault_test_client.logical.write("#{VAULT_PATH}/data/api", { "data" => { value: 'api_specific'} } )
+          vault_test_client.kv(VAULT_PATH).write("common/test_key", { value: 'default'} )
+          vault_test_client.kv(VAULT_PATH).write("rproxy/ssl", { value: 'ssl'} )
+          vault_test_client.kv(VAULT_PATH).write("api/oauth", { value: 'oauth'} )
+          vault_test_client.kv(VAULT_PATH).write("api", { value: 'api_specific'}  )
         end
 
         context 'reading secrets' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rspec-puppet'
-require 'puppetlabs_spec_helper/module_spec_helper'
 
 require 'simplecov'
 require 'simplecov-console'
@@ -54,3 +53,5 @@ RSpec.configure do |config|
     config.warnings = false
   end
 end
+
+require 'puppetlabs_spec_helper/module_spec_helper'


### PR DESCRIPTION
We've been using Vault at one of teams in Opera pretty extensively over the past couple of years.

There's one big change here: allowing for comma-delimited paths, since we are whitelisting multiple paths for each machine:
```yaml
  - name: "Hiera-vault lookup"
    lookup_key: "hiera_vault"
    options:
      mounts:
        kv2:
          - "secret/data/puppet/%{trusted.extensions.pp_role}"
          - "secret/data/puppet/common"
```
(see spec/functions/hiera_vault_path_interpolation_spec.rb )

This PR is a result of recent rebase - let me know what you think.

I'll ensure this works for us in the meantime and remove draft status :)