### PR TITLE
WIP: Implement IAM Authentication

### DIFF
--- a/lib/puppet/functions/hiera_vault.rb
+++ b/lib/puppet/functions/hiera_vault.rb
@@ -119,7 +119,7 @@ Puppet::Functions.create_function(:hiera_vault) do
 
 
       begin
-        $vault.configure do |config|
+        $hiera_vault_client.configure do |config|
           config.address = options['address'] unless options['address'].nil?
           config.ssl_pem_file = options['ssl_pem_file'] unless options['ssl_pem_file'].nil?
           config.ssl_verify = options['ssl_verify'] unless options['ssl_verify'].nil?
@@ -129,7 +129,7 @@ Puppet::Functions.create_function(:hiera_vault) do
 
           if options.key?("authentication")
             context.explain { "[hiera-vault] Using #{options['authentication']['type']} authentication" }
-            authenticate(options['authentication'], $vault, context)
+            authenticate(options['authentication'], $hiera_vault_client, context)
           else
             context.explain { "[hiera-vault] Using token authentication" }
             config.token = vault_token(options)

--- a/lib/puppet/functions/hiera_vault.rb
+++ b/lib/puppet/functions/hiera_vault.rb
@@ -74,7 +74,7 @@ Puppet::Functions.create_function(:hiera_vault) do
     end
 
     if vault_token(options).nil? && !options.key?("authentication")
-      raise ArgumentError, '[hiera-vault] no token set in options and no token in VAULT_TOKEN'
+      raise ArgumentError, '[hiera-vault] no token set in options, no token in VAULT_TOKEN and no special authentication configured'
     end
 
     result = vault_get(key, options, context)
@@ -110,8 +110,10 @@ Puppet::Functions.create_function(:hiera_vault) do
         config.ssl_ciphers = options['ssl_ciphers'] if config.respond_to? :ssl_ciphers
 
         if options.key?("authentication")
-          authenticate(options['authentication'], $vault)
+          context.explain { "[hiera-vault] Using #{options['authentication']['type']} authentication" }
+          authenticate(options['authentication'], $vault, context)
         else
+          context.explain { "[hiera-vault] Using token authentication" }
           config.token = vault_token(options)
         end
       end

--- a/lib/puppet/functions/special_auth.rb
+++ b/lib/puppet/functions/special_auth.rb
@@ -1,0 +1,28 @@
+def authenticate(options, client, context)
+
+  auth_types = {
+    'aws_iam' => method(:aws_iam_auth)
+  }
+
+  auth_types[options['type']].(options['config'], client)
+
+end
+
+
+def aws_iam_auth(config, client)
+
+  # require set in method to avoid necessary installation of every gem for every auth method, even if not used
+  # Possibly inefficient if we're constantly calling this function
+  # The alternative is to add the require to hiera_vault.rb
+  begin
+    require 'aws-sdk-core'
+  rescue LoadError => e
+    raise Puppet::DataBinding::LookupError, "[hiera-vault] Must install aws-sdk-core gem to use AWS IAM authentication"
+  end
+
+  role = config['role']
+
+  client.auth.aws_iam(role, Aws::InstanceProfileCredentials.new)
+
+end
+

--- a/lib/puppet/functions/special_auth.rb
+++ b/lib/puppet/functions/special_auth.rb
@@ -4,21 +4,20 @@ def authenticate(options, client, context)
     'aws_iam' => method(:aws_iam_auth)
   }
 
-  auth_types[options['type']].(options['config'], client)
+  auth_types[options['type']].(options['config'], client, context)
 
 end
 
 
-def aws_iam_auth(config, client)
+def aws_iam_auth(config, client, context)
 
-  # require set in method to avoid necessary installation of every gem for every auth method, even if not used
-  # Possibly inefficient if we're constantly calling this function
-  # The alternative is to add the require to hiera_vault.rb
   begin
     require 'aws-sdk-core'
   rescue LoadError => e
     raise Puppet::DataBinding::LookupError, "[hiera-vault] Must install aws-sdk-core gem to use AWS IAM authentication"
   end
+
+  context.explain { "[hiera-vault] Starting aws_iam authentication with config: #{config}" }
 
   role = config['role']
 


### PR DESCRIPTION
*These changes are a WIP* 😄 

# Summary

This proposal is to add different Vault authentication mechanisms to this plugin, as an alternative to using the Token directly

There are a number built into Vault that would be feasible: https://www.vaultproject.io/docs/auth

# Implementation

The authentication portion is completed in the `special_auth.rb` file. Currently, configuration for IAM is only specified, however this is setup in a way that adding new authentication methods should be plug-and-play

For example, adding GitHub authentication would look like: (pseudocode)

```
def authenticate(options, client, context)

  auth_types = {
    'aws_iam' => method(:aws_iam_auth),
    'github'     => method(:github_auth)
  }

  auth_types[options['type']].(options['config'], client, context)

end


def github_auth(config, client, context)

    # Logic for Github authentication 
    client.auth.github()

end
```

The `client` returned from these functions would be authenticated and ready to use

# Configuration Changes

To implement this, the configuration would need to be altered. The `token` section can be omitted, with a new `authentication` section added:

For example, a current config may look like:

```
---

version: 5

hierarchy:
  - name: "Hiera-vault lookup"
    lookup_key: hiera_vault
    options:
      confine_to_keys:
        - '^vault_.*'
        - '^.*_password$'
        - '^password.*'
      ssl_verify: false
      address: https://vault.foobar.com:8200
      token: <insert-your-vault-token-here>
      default_field: value
      mounts:
        some_secret:
          - %{::trusted.certname}
          - common
        another_secret:
          - %{::trusted.certname}
          - common

```

Here is a similar config, using IAM authentication:

```
---

version: 5

hierarchy:
  - name: "Hiera-vault lookup"
    lookup_key: hiera_vault
    options:
      confine_to_keys:
        - '^vault_.*'
        - '^.*_password$'
        - '^password.*'
      ssl_verify: false
      address: https://vault.foobar.com:8200
      authentication:
        type: aws_iam
        config:
          role: vault-client-role
      default_field: value
      mounts:
        some_secret:
          - %{::trusted.certname}
          - common
        another_secret:
          - %{::trusted.certname}
          - common

```

The main difference is this snippet here:

```
authentication:
  type: iam
  config:
    iam_role: vault-client-role
```

This would allow any different form of authentication to be supported, even though they may require different configurations

The hiarchy of authentication methods are as follows:

1. VAULT_TOKEN environment variable
2. `token` specified in the configuration
3. `authentication` specified in the configuration

Each type will need to be specified in the `special_auth.rb` function

# Next Steps

I'm opening this PR in WIP status to get the conversation going 😄 

The following would still need to be worked on: 
- Tests
- Document updates 

Are any maintainers able to provide some input into a possible testing strategy for this? I have Terraform code available to create a full end-to-end test in AWS, but not sure how well that'd fit into the current testing patterns 😅 

Thanks!! 

