### PR TITLE
Bailout on http errors, add strict_mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,11 +151,13 @@ strip_from_keys:
   - "vault:"
 ```
 
-`default_field:`: The default field within data to return. If not present, the lookup will be the full contents of the secret data.
+`default_field`: The default field within data to return. If not present, the lookup will be the full contents of the secret data.
 
-`mounts:`: The list of mounts you want to do lookups against. This is treated as the backend hiearchy for lookup. It is recomended you use [Trusted Facts](https://puppet.com/docs/puppet/5.3/lang_facts_and_builtin_vars.html#trusted-facts) within the hierachy to ensure lookups are restricted to the correct hierachy points. See [Mounts](#mounts).
+`mounts`: The list of mounts you want to do lookups against. This is treated as the backend hiearchy for lookup. It is recomended you use [Trusted Facts](https://puppet.com/docs/puppet/5.3/lang_facts_and_builtin_vars.html#trusted-facts) within the hierachy to ensure lookups are restricted to the correct hierachy points. See [Mounts](#mounts).
 
-`:ssl_verify`: Specify whether to verify SSL certificates (default: true)
+`ssl_verify`: Specify whether to verify SSL certificates (default: true)
+
+`strict_mode`: Whether to fail loudly when we get a 403 response or no result from Vault. Otherwise we get an empty result, which means passwords could become empty strings.
 
 `v1_lookup`: whether to lookup within kv v1 hierarchy (default `true`) - disable if you only use kv v2 :) See [Less lookups](#less-lookups).
 


### PR DESCRIPTION
We let the lookup function fail in case of http errors when looking up a
secret. Furthermore, we add strict_mode, that if set, will fail puppet
when a secret cannot be found in any of the paths. This should only be
used in combination of confine_to_keys.

Signed-off-by: Peter Verraedt <peter.verraedt@kuleuven.be>