### PR TITLE
Add cache support

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ The following are optional configuration parameters supported in the `options` h
 
 `token`: The token to authenticate with Vault, also read as `ENV["VAULT_TOKEN"]` or a full path to the file with the token (eg. `/etc/vault_token.txt`). When bootstrapping, you can set this token as `IGNORE-VAULT` and the backend will be stubbed, which can be useful when bootstrapping.
 
+`cache_for`: How long to cache a given key in seconds. If not present the response will never be cached.
+
 `confine_to_keys:`: Only use this backend if the key matches one of the regexes in the array, to avoid constantly reaching out to Vault for every parameter lookup
 
 ```yaml
@@ -218,6 +220,8 @@ Secrets will then be looked up with the following paths:
 - http://vault.foobar.com:8200/some_secret/data/common/cool_key (for v2)
 
 #### Less lookups
+
+It is possible to use `cache_for` to indicate how long to cache a given key to lessen the number of requests sent to Vault.
 
 You can use `v1_lookup` and `v2_guess_mount` to minimize misses in above lookups.
 

--- a/spec/functions/hiera_vault_cache_spec.rb
+++ b/spec/functions/hiera_vault_cache_spec.rb
@@ -1,0 +1,112 @@
+require 'spec_helper'
+require 'support/vault_server'
+require 'puppet/functions/hiera_vault'
+
+describe FakeFunction do
+  let :function do
+    described_class.new
+  end
+
+  let :context do
+    ctx = instance_double('Puppet::LookupContext')
+    allow(ctx).to receive(:cache_has_key).and_return(false)
+    if ENV['DEBUG']
+      allow(ctx).to receive(:explain) { |&block| puts(block.call) }
+    else
+      allow(ctx).to receive(:explain).and_return(:nil)
+    end
+    allow(ctx).to receive(:not_found)
+    allow(ctx).to receive(:cache).with(String, anything) do |_, val|
+      val
+    end
+    allow(ctx).to receive(:interpolate).with(anything) do |val|
+      val
+    end
+    ctx
+  end
+
+  let :vault_options do
+    {
+      'address' => RSpec::VaultServer.address,
+      'token' => RSpec::VaultServer.token,
+      'mounts' => {
+        'puppetcache' => [
+          'common'
+        ]
+      }
+    }
+  end
+
+  def vault_test_client
+    Vault::Client.new(
+      address: RSpec::VaultServer.address,
+      token: RSpec::VaultServer.token
+    )
+  end
+
+  describe '#lookup_key' do
+
+
+    context 'when vault is unsealed' do
+      before(:context) do
+        vault_test_client.sys.mount('puppetcache', 'kv', 'puppet secrets v1', { "options" => {"version": "1" }})
+      end
+
+      it 'should error when cache_for is not nil or a number' do
+        expect { function.lookup_key('test_key', vault_options.merge('cache_for' => 'invalid'), context) }
+          .to raise_error(ArgumentError, '[hiera-vault] invalid value for cache_for: \'invalid\', should be a number or nil')
+      end
+
+      it 'should not cache the response when cache_for is not set' do
+        vault_test_client.logical.write('puppetcache/common/test_key', value: 'default')
+
+        expect(function.lookup_key('test_key', vault_options, context))
+          .to eq('value' => 'default')
+
+        vault_test_client.logical.write('puppetcache/common/test_key', value: 'overwritten')
+
+        expect(function.lookup_key('test_key', vault_options, context))
+          .to eq('value' => 'overwritten')
+      end
+
+      it 'should cache the response for cache_for seconds when cache_for is set' do
+        vault_test_client.logical.write('puppetcache/common/test_key', value: 'default')
+
+        expect(function.lookup_key('test_key', vault_options.merge('cache_for' => 1), context))
+          .to eq('value' => 'default')
+
+        vault_test_client.logical.write('puppetcache/common/test_key', value: 'overwritten')
+
+        expect(function.lookup_key('test_key', vault_options.merge('cache_for' => 1), context))
+          .to eq('value' => 'default')
+
+        sleep(2)
+
+        expect(function.lookup_key('test_key', vault_options.merge('cache_for' => 1), context))
+          .to eq('value' => 'overwritten')
+      end
+
+      it 'should cache even if there is no value in Vault' do
+        expect(function.lookup_key('missed', vault_options.merge('cache_for' => 1), context))
+          .to eq(nil)
+
+        vault_test_client.logical.write('puppetcache/common/missed', value: 'overwritten')
+
+        expect(function.lookup_key('missed', vault_options.merge('cache_for' => 1), context))
+          .to eq(nil)
+      end
+
+      it 'should not cache the response when options changes' do
+        vault_test_client.logical.write('puppetcache/common/options_change', value: 'default')
+
+        expect(function.lookup_key('options_change', vault_options.merge('cache_for' => 1), context))
+          .to eq('value' => 'default')
+
+        vault_test_client.logical.write('puppetcache/common/options_change', value: 'overwritten')
+
+        expect(function.lookup_key('options_change', vault_options.merge('cache_for' => 2), context))
+          .to eq('value' => 'overwritten')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This patch adds an optional cache to this module that makes it easier to not send duplicated requests to the Vault server. 

When the cache is not explicitly activated the behaviour is the same as before.

When `cache_for` is set secrets are kept in memory for `cache_for` seconds to avoid sending multiple time the same request and lessen the load on the Vault server.