### PR TITLE
Fixed interpolate path split to allow / path

### DIFF
--- a/lib/puppet/functions/hiera_vault.rb
+++ b/lib/puppet/functions/hiera_vault.rb
@@ -340,7 +340,7 @@ Puppet::Functions.create_function(:hiera_vault) do
       path = context.interpolate(path)
       # TODO: Unify usage of '/' - File.join seems to be a mistake, since it won't work on Windows
       # secret/puppet/scope1,scope2 => [[secret], [puppet], [scope1, scope2]]
-      segments = path.split('/').map { |segment| segment.split(',') }
+      segments = path.split(/(?=\/)/).map { |segment| segment.split(',') }
       allowed_paths += build_paths(segments) unless segments.empty?
     end
     allowed_paths

--- a/spec/functions/hiera_vault_path_interpolation_spec.rb
+++ b/spec/functions/hiera_vault_path_interpolation_spec.rb
@@ -37,7 +37,8 @@ describe FakeFunction do
       'mounts' => {
         VAULT_PATH + "/data" => [
           'common',
-          'rproxy,api'
+          'rproxy,api',
+          '/'
         ]
       }
     }
@@ -59,6 +60,7 @@ describe FakeFunction do
           vault_test_client.kv(VAULT_PATH).write("rproxy/ssl", { value: 'ssl'} )
           vault_test_client.kv(VAULT_PATH).write("api/oauth", { value: 'oauth'} )
           vault_test_client.kv(VAULT_PATH).write("api", { value: 'api_specific'}  )
+          vault_test_client.kv(VAULT_PATH).write("/root", { value: 'root_specific'} )
         end
 
         context 'reading secrets' do
@@ -80,6 +82,10 @@ describe FakeFunction do
           it 'returns key from second option with full path to node' do
             expect(function.lookup_key('api/oauth', vault_options, context))
               .to include('value' => 'oauth')
+          end
+          it 'returns key from root path' do
+            expect(function.lookup_key('/root', vault_options, context))
+              .to include('value' => 'root_specific')
           end
         end
       end


### PR DESCRIPTION
Changes to the interpolate function to split the path has broken the vault lookups for us (Working in Release v1.0.0).

The interpolate function on line 343 (https://github.com/petems/petems-hiera_vault/blob/master/lib/puppet/functions/hiera_vault.rb#L343) does not account for "/" as a valid path, resulting in secrets under "/" path are not fetched

In our Puppet environment we have the following hiera.yaml:

```yaml
- name: "Hiera-vault lookup"
    lookup_key: "hiera_vault"
    options:
      mounts:
        kv2:
          - "/"
          - "common"
```

PR is to update the string split to include "/" path
